### PR TITLE
Support for regex flags

### DIFF
--- a/hypothesis_regex.py
+++ b/hypothesis_regex.py
@@ -1,102 +1,330 @@
+from collections import namedtuple
+import re
+import six
 import six.moves
 import string
 import sre_parse as sre
+import sys
+import hypothesis.errors as he
 import hypothesis.strategies as hs
 from hypothesis.searchstrategy.reprwrapper import ReprWrapperStrategy
 
 __all__ = ['regex']
 
 
-_CATEGORIES = {
-    sre.CATEGORY_DIGIT: string.digits,
-    sre.CATEGORY_NOT_DIGIT: string.ascii_letters + string.punctuation,
-    sre.CATEGORY_SPACE: string.whitespace,
-    sre.CATEGORY_NOT_SPACE: string.printable.strip(),
-    sre.CATEGORY_WORD: string.ascii_letters + string.digits + '_',
-    sre.CATEGORY_NOT_WORD: ''.join(
-        set(string.printable).difference(
-            string.ascii_letters + string.digits + '_'
-        )
-    )
-}
+HAS_SUBPATTERN_FLAGS = sys.version_info[:2] >= (3, 6)
+
+
+UNICODE_CATEGORIES = set([
+    'Cf', 'Cn', 'Co', 'LC', 'Ll', 'Lm', 'Lo', 'Lt', 'Lu',
+    'Mc', 'Me', 'Mn', 'Nd', 'Nl', 'No', 'Pc', 'Pd', 'Pe',
+    'Pf', 'Pi', 'Po', 'Ps', 'Sc', 'Sk', 'Sm', 'So', 'Zl',
+    'Zp', 'Zs',
+])
+
+
+SPACE_CHARS = u' \t\n\r\f\v'
+UNICODE_SPACE_CHARS = SPACE_CHARS + u'\x1c\x1d\x1e\x1f\x85'
+UNICODE_DIGIT_CATEGORIES = set(['Nd'])
+UNICODE_SPACE_CATEGORIES = set(['Zs', 'Zl', 'Zp'])
+UNICODE_LETTER_CATEGORIES = set(['LC', 'Ll', 'Lm', 'Lo', 'Lt', 'Lu'])
+UNICODE_WORD_CATEGORIES = UNICODE_LETTER_CATEGORIES | set(['Nd', 'Nl', 'No'])
+
+HAS_WEIRD_WORD_CHARS = (2, 7) <= sys.version_info[:2] < (3, 4)
+UNICODE_WEIRD_NONWORD_CHARS = u'\U00012432\U00012433\U00012456\U00012457'
+
+
+class Context(object):
+    __slots__ = ['groups', 'flags']
+
+    def __init__(self, groups=None, flags=0):
+        self.groups = groups or {}
+        self.flags = flags
+
+
+class CharactersBuilder(object):
+    '''
+    Helper object that allows to configure `characters()` strategy with various
+    unicode categories and characters. Also allows negation of configured set.
+
+    :param negate: If True, configure `characters()` to match anything other than
+        configured character set
+    :param flags: Regex flags. They affect how and which characters are matched
+    '''
+    def __init__(self, negate=False, flags=0):
+        self._categories = set()
+        self._whitelist_chars = set()
+        self._blacklist_chars = set()
+        self._negate = negate
+        self._ignorecase = flags & re.IGNORECASE
+        self._unicode = (not flags & re.ASCII) \
+            if six.PY3 else bool(flags & re.UNICODE)
+
+    @property
+    def strategy(self):
+        'Returns resulting strategy that generates configured char set'
+        max_codepoint = None if self._unicode else 127
+
+        strategies = []
+        if self._negate:
+            if self._categories or self._whitelist_chars:
+                strategies.append(
+                    hs.characters(
+                        blacklist_categories=self._categories | set(['Cc', 'Cs']),
+                        blacklist_characters=self._whitelist_chars,
+                        max_codepoint=max_codepoint,
+                    )
+                )
+            if self._blacklist_chars:
+                strategies.append(
+                    hs.sampled_from(
+                        list(self._blacklist_chars - self._whitelist_chars)
+                    )
+                )
+        else:
+            if self._categories or self._blacklist_chars:
+                strategies.append(
+                    hs.characters(
+                        whitelist_categories=self._categories,
+                        blacklist_characters=self._blacklist_chars,
+                        max_codepoint=max_codepoint,
+                    )
+                )
+            if self._whitelist_chars:
+                strategies.append(
+                    hs.sampled_from(
+                        list(self._whitelist_chars - self._blacklist_chars)
+                    )
+                )
+
+        return hs.one_of(*strategies) if strategies else hs.just(u'')
+
+    def add_category(self, category):
+        '''
+        Add unicode category to set
+
+        Unicode categories are strings like 'Ll', 'Lu', 'Nd', etc.
+        See `unicodedata.category()`
+        '''
+        if category == sre.CATEGORY_DIGIT:
+            self._categories |= UNICODE_DIGIT_CATEGORIES
+        elif category == sre.CATEGORY_NOT_DIGIT:
+            self._categories |= UNICODE_CATEGORIES - UNICODE_DIGIT_CATEGORIES
+        elif category == sre.CATEGORY_SPACE:
+            self._categories |= UNICODE_SPACE_CATEGORIES
+            for c in (UNICODE_SPACE_CHARS if self._unicode else SPACE_CHARS):
+                self._whitelist_chars.add(c)
+        elif category == sre.CATEGORY_NOT_SPACE:
+            self._categories |= UNICODE_CATEGORIES - UNICODE_SPACE_CATEGORIES
+            for c in (UNICODE_SPACE_CHARS if self._unicode else SPACE_CHARS):
+                self._blacklist_chars.add(c)
+        elif category == sre.CATEGORY_WORD:
+            self._categories |= UNICODE_WORD_CATEGORIES
+            self._whitelist_chars.add(u'_')
+            if HAS_WEIRD_WORD_CHARS and self._unicode:
+                for c in UNICODE_WEIRD_NONWORD_CHARS:
+                    self._blacklist_chars.add(c)
+        elif category == sre.CATEGORY_NOT_WORD:
+            self._categories |= UNICODE_CATEGORIES - UNICODE_WORD_CATEGORIES
+            self._blacklist_chars.add(u'_')
+            if HAS_WEIRD_WORD_CHARS and self._unicode:
+                for c in UNICODE_WEIRD_NONWORD_CHARS:
+                    self._whitelist_chars.add(c)
+
+    def add_chars(self, chars):
+        'Add given chars to char set'
+        for c in chars:
+            if self._ignorecase:
+                self._whitelist_chars.add(c.lower())
+                self._whitelist_chars.add(c.upper())
+            else:
+                self._whitelist_chars.add(c)
 
 
 @hs.defines_strategy
 def regex(regex):
-    """Return strategy that generates strings that match given regex."""
-    if hasattr(regex, 'pattern'):
-        regex = regex.pattern
+    """Return strategy that generates strings that match given regex.
 
-    codes = sre.parse(regex)
+    Regex can be either a string or compiled regex (through `re.compile()`).
 
-    return ReprWrapperStrategy(_strategy(codes, {}), 'regex(%s)' % repr(regex))
+    You can use regex flags (such as `re.IGNORECASE`, `re.DOTALL` or `re.UNICODE`)
+    to control generation. Flags can be passed either in compiled regex (specify
+    flags in call to `re.compile()`) or inside pattern with (?iLmsux) group.
+
+    Some tricky regular expressions are partly supported or not supported at all.
+    "^" and "$" do not affect generation. Positive lookahead/lookbehind groups
+    are considered normal groups. Negative lookahead/lookbehind groups do not do
+    anything. Ternary regex groups ('(?(name)yes-pattern|no-pattern)') are not
+    supported at all.
+    """
+    if not hasattr(regex, 'pattern'):
+        regex = re.compile(regex)
+
+    pattern = regex.pattern
+    flags = regex.flags
+
+    codes = sre.parse(pattern)
+
+    return _strategy(codes, Context(flags=flags)).filter(regex.match)
 
 
-def _strategy(codes, cache):
+def _strategy(codes, context):
+    """
+    Convert SRE regex parse tree to strategy that generates strings matching that
+    regex represented by that parse tree.
+
+    `codes` is either a list of SRE regex elements representations or a particular
+    element representation. Each element is a tuple of element code (as string) and
+    parameters. E.g. regex 'ab[0-9]+' compiles to following elements:
+
+        [
+            ('literal', 97),
+            ('literal', 98),
+            ('max_repeat', (1, 4294967295, [
+                ('in', [
+                    ('range', (48, 57))
+                ])
+            ]))
+        ]
+
+    The function recursively traverses regex element tree and converts each element
+    to strategy that generates strings that match that element.
+
+    Context stores
+    1. List of groups (for backreferences)
+    2. Active regex flags (e.g. IGNORECASE, DOTALL, UNICODE, they affect behavior
+       of various inner strategies)
+    """
     if not isinstance(codes, tuple):
-        return hs.tuples(*[_strategy(x, cache) for x in codes]).map(''.join)
+        # List of codes
+        strategies = []
+
+        i = 0
+        while i < len(codes):
+            if codes[i][0] == sre.LITERAL and not (context.flags & re.IGNORECASE):
+                # Merge subsequent "literals" into one `just()` strategy
+                # that generates corresponding text if no IGNORECASE
+                j = i + 1
+                while j < len(codes) and codes[j][0] == sre.LITERAL:
+                    j += 1
+
+                strategies.append(hs.just(
+                    u''.join([six.unichr(charcode) for (_, charcode) in codes[i:j]])
+                ))
+
+                i = j
+            else:
+                strategies.append(_strategy(codes[i], context))
+                i += 1
+
+        return hs.tuples(*strategies).map(u''.join)
     else:
+        # Single code
         code, value = codes
         if code == sre.LITERAL:
-            return hs.just(chr(value))
+            # Regex 'a' (single char)
+            c = six.unichr(value)
+            if context.flags & re.IGNORECASE:
+                return hs.sampled_from([c.lower(), c.upper()])
+            else:
+                return hs.just(c)
+
         elif code == sre.NOT_LITERAL:
-            return hs.characters(blacklist_characters=[chr(value)])
+            # Regex '[^a]' (negation of a single char)
+            c = six.unichr(value)
+            blacklist = set([c.lower(), c.upper()]) \
+                if context.flags & re.IGNORECASE else [c]
+            return hs.characters(blacklist_characters=blacklist)
+
         elif code == sre.IN:
+            # Regex '[abc0-9]' (set of characters)
             charsets = value
 
-            chars = []
+            builder = CharactersBuilder(negate=charsets[0][0] == sre.NEGATE,
+                                        flags=context.flags)
+
             for charset_code, charset_value in charsets:
                 if charset_code == sre.NEGATE:
+                    # Regex '[^...]' (negation)
                     pass
                 elif charset_code == sre.LITERAL:
-                    chars.append(chr(charset_value))
+                    # Regex '[a]' (single char)
+                    builder.add_chars(six.unichr(charset_value))
                 elif charset_code == sre.RANGE:
+                    # Regex '[a-z]' (char range)
                     low, high = charset_value
-                    chars.extend([
-                        chr(x) for x in six.moves.range(low, high+1)
-                    ])
+                    for x in six.moves.range(low, high+1):
+                        builder.add_chars(six.unichr(x))
                 elif charset_code == sre.CATEGORY:
-                    if charset_value not in _CATEGORIES:
-                        raise NotImplementedError(
-                            'Unknown char category: %s' % charset_value
-                        )
-                    chars.extend(_CATEGORIES[charset_value])
+                    # Regex '[\w]' (char category)
+                    builder.add_category(charset_value)
                 else:
-                    raise NotImplementedError(
+                    raise he.InvalidArgument(
                         'Unknown charset code: %s' % charset_code
                     )
 
-            if charsets[0][0] == sre.NEGATE:
-                return hs.characters(blacklist_characters=chars)
-            else:
-                return hs.text(alphabet=chars, min_size=1, max_size=1)
+            return builder.strategy
 
         elif code == sre.ANY:
-            # TODO: consider checking MULTILINE flag
-            return hs.characters(blacklist_characters="\n")
+            # Regex '.' (any char)
+            if context.flags & re.DOTALL:
+                return hs.characters()
+            else:
+                return hs.characters(blacklist_characters="\n")
+
         elif code == sre.AT:
+            # Regexes like '^...', '...$', '\bfoo', '\Bfoo'
+            if value == sre.AT_END:
+                return hs.one_of(hs.just(u''), hs.just(u'\n'))
             return hs.just('')
+
         elif code == sre.SUBPATTERN:
-            strat = hs.tuples(*[_strategy(part, cache)
-                                for part in value[-1]]).map(''.join)
+            # Various groups: '(...)', '(:...)' or '(?P<name>...)'
+            old_flags = context.flags
+            if HAS_SUBPATTERN_FLAGS:
+                context.flags = (context.flags | value[1]) & ~value[2]
+
+            strat = _strategy(value[-1], context)
+
+            context.flags = old_flags
+
             if value[0]:
-                cache[value[0]] = strat
+                context.groups[value[0]] = strat
                 strat = hs.shared(strat, key=value[0])
+
             return strat
+
         elif code == sre.GROUPREF:
-            return hs.shared(cache[value], key=value)
+            # Regex '\\1' or '(?P=name)' (group reference)
+            return hs.shared(context.groups[value], key=value)
+
         elif code == sre.ASSERT:
-            return _strategy(value[1], cache)
+            # Regex '(?=...)' or '(?<=...)' (positive lookahead/lookbehind)
+            return _strategy(value[1], context)
+
         elif code == sre.ASSERT_NOT:
+            # Regex '(?!...)' or '(?<!...)' (negative lookahead/lookbehind)
             return hs.just('')
+
         elif code == sre.BRANCH:
-            return hs.one_of([_strategy(branch, cache) for branch in value[1]])
+            # Regex 'a|b|c' (branch)
+            return hs.one_of([_strategy(branch, context) for branch in value[1]])
+
         elif code in [sre.MIN_REPEAT, sre.MAX_REPEAT]:
+            # Regexes 'a?', 'a*', 'a+' and their non-greedy variants (repeaters)
             at_least, at_most, regex = value
             if at_most == 4294967295:
                 at_most = None
-            return hs.lists(_strategy(regex, cache),
+            return hs.lists(_strategy(regex, context),
                             min_size=at_least,
                             max_size=at_most).map(''.join)
+
+        elif code == sre.GROUPREF_EXISTS:
+            # Regex '(?(id/name)yes-pattern|no-pattern)' (if group exists selection)
+            return hs.one_of(
+                _strategy(value[1], context),
+                _strategy(value[2], context) if value[2] else hs.just(u''),
+            )
+
         else:
-            raise NotImplementedError('Unknown code point: %s' % repr(code))
+            raise he.InvalidArgument('Unknown code point: %s' % repr(code))

--- a/tests/test_regex.py
+++ b/tests/test_regex.py
@@ -1,3 +1,5 @@
+import hypothesis as h
+import hypothesis.errors as he
 import hypothesis_regex
 import pytest
 import re
@@ -5,11 +7,13 @@ import six.moves
 
 
 def assert_can_generate(pattern):
+    regex = re.compile(pattern)
     strategy = hypothesis_regex.regex(pattern)
-    for _ in six.moves.range(100):
-        s = strategy.example()
-        assert re.match(pattern, s) is not None, \
-            '"%s" supposed to match "%s" (strategy = %s)' % (s, pattern, strategy)
+
+    h.find(strategy, lambda s: regex.match(s) is not None)
+
+    with pytest.raises(he.NoSuchExample):
+        h.find(strategy, lambda s: regex.match(s) is None)
 
 
 class TestRegexStrategy:

--- a/tests/test_regex.py
+++ b/tests/test_regex.py
@@ -1,27 +1,175 @@
 import hypothesis as h
 import hypothesis.errors as he
-import hypothesis_regex
+
+from hypothesis_regex import regex, UNICODE_CATEGORIES, UNICODE_DIGIT_CATEGORIES, \
+    UNICODE_SPACE_CATEGORIES, UNICODE_WORD_CATEGORIES, UNICODE_WEIRD_NONWORD_CHARS, \
+    SPACE_CHARS, UNICODE_SPACE_CHARS, HAS_WEIRD_WORD_CHARS
 import pytest
 import re
+import six
 import six.moves
+import sys
+import unicodedata
+
+
+def is_ascii(s):
+    return all(ord(c) < 128 for c in s)
+
+
+def is_digit(s):
+    return all(unicodedata.category(c) in UNICODE_DIGIT_CATEGORIES for c in s)
+
+
+def is_space(s):
+    return all(c in SPACE_CHARS for c in s)
+
+
+def is_unicode_space(s):
+    return all(
+        unicodedata.category(c) in UNICODE_SPACE_CATEGORIES or \
+        c in UNICODE_SPACE_CHARS
+        for c in s
+    )
+
+
+def is_word(s):
+    return all(
+        c == '_' or (
+            (not HAS_WEIRD_WORD_CHARS or c not in UNICODE_WEIRD_NONWORD_CHARS) and
+            unicodedata.category(c) in UNICODE_WORD_CATEGORIES
+        )
+        for c in s
+    )
+
+
+def ascii_regex(pattern):
+    flags = re.ASCII if six.PY3 else 0
+    return re.compile(pattern, flags)
+
+
+def unicode_regex(pattern):
+    return re.compile(pattern, re.UNICODE)
+
+
+class TestRegexUnicodeMatching:
+    def _test_matching_pattern(self, pattern, isvalidchar, unicode=False):
+        r = unicode_regex(pattern) if unicode else ascii_regex(pattern)
+
+        codepoints = six.moves.range(0, sys.maxunicode+1) \
+            if unicode else six.moves.range(1, 128)
+        for c in [six.unichr(x) for x in codepoints]:
+            if isvalidchar(c):
+                assert r.match(c), (
+                    '"%s" supposed to match "%s" (%r, category "%s"), '
+                    'but it doesnt' % (pattern, c, c, unicodedata.category(c))
+                )
+            else:
+                assert not r.match(c), (
+                    '"%s" supposed not to match "%s" (%r, category "%s"), '
+                    'but it does' % (pattern, c, c, unicodedata.category(c))
+                )
+
+    def test_matching_ascii_word_chars(self):
+        self._test_matching_pattern(r'\w', is_word)
+
+    def test_matching_unicode_word_chars(self):
+        self._test_matching_pattern(r'\w', is_word, unicode=True)
+
+    def test_matching_ascii_non_word_chars(self):
+        self._test_matching_pattern(r'\W', lambda s: not is_word(s))
+
+    def test_matching_unicode_non_word_chars(self):
+        self._test_matching_pattern(r'\W', lambda s: not is_word(s), unicode=True)
+
+    def test_matching_ascii_digits(self):
+        self._test_matching_pattern(r'\d', is_digit)
+
+    def test_matching_unicode_digits(self):
+        self._test_matching_pattern(r'\d', is_digit, unicode=True)
+
+    def test_matching_ascii_non_digits(self):
+        self._test_matching_pattern(r'\D', lambda s: not is_digit(s))
+
+    def test_matching_unicode_non_digits(self):
+        self._test_matching_pattern(r'\D', lambda s: not is_digit(s), unicode=True)
+
+    def test_matching_ascii_spaces(self):
+        self._test_matching_pattern(r'\s', is_space)
+
+    def test_matching_unicode_spaces(self):
+        self._test_matching_pattern(r'\s', is_unicode_space, unicode=True)
+
+    def test_matching_ascii_non_spaces(self):
+        self._test_matching_pattern(r'\S', lambda s: not is_space(s))
+
+    def test_matching_unicode_non_spaces(self):
+        self._test_matching_pattern(r'\S', lambda s: not is_unicode_space(s),
+                                    unicode=True)
+
+
+def assert_all_examples(strategy, predicate):
+    '''
+    Checks that there are no examples with given strategy
+    that do not match predicate.
+
+    :param strategy: Hypothesis strategy to check
+    :param predicate: (callable) Predicate that takes string example and returns bool
+    '''
+    @h.settings(max_examples=1000, max_iterations=5000)
+    @h.given(strategy)
+    def assert_examples(s):
+        assert predicate(s),'Found %r using strategy %s which does not match' % (
+            s, strategy,
+        )
+
+    assert_examples()
 
 
 def assert_can_generate(pattern):
-    regex = re.compile(pattern)
-    strategy = hypothesis_regex.regex(pattern)
+    '''
+    Checks that regex strategy for given pattern generates examples
+    that match that regex pattern
+    '''
+    compiled_pattern = re.compile(pattern)
+    strategy = regex(pattern)
 
-    h.find(strategy, lambda s: regex.match(s) is not None)
-
-    with pytest.raises(he.NoSuchExample):
-        h.find(strategy, lambda s: regex.match(s) is None)
+    assert_all_examples(strategy, compiled_pattern.match)
 
 
 class TestRegexStrategy:
-    def test_literals(self):
-        assert_can_generate('abc')
+    @pytest.mark.parametrize('pattern', ['abc', '[a][b][c]'])
+    def test_literals(self, pattern):
+        assert_can_generate(pattern)
+
+    @pytest.mark.parametrize('pattern', [re.compile('a', re.IGNORECASE), '(?i)a'])
+    def test_literals_with_ignorecase(self, pattern):
+        strategy = regex(pattern)
+
+        h.find(strategy, lambda s: s == 'a')
+        h.find(strategy, lambda s: s == 'A')
+
+    def test_not_literal(self):
+        assert_can_generate('[^a][^b][^c]')
+
+    @pytest.mark.parametrize('pattern', [
+        re.compile('[^a][^b]', re.IGNORECASE),
+        '(?i)[^a][^b]'
+    ])
+    def test_not_literal_with_ignorecase(self, pattern):
+        assert_all_examples(
+            regex(pattern),
+            lambda s: s[0] not in ('a', 'A') and s[1] not in ('b', 'B')
+        )
 
     def test_any(self):
         assert_can_generate('.')
+
+    def test_any_doesnt_generate_newline(self):
+        assert_all_examples(regex('.'), lambda s: s != '\n')
+
+    @pytest.mark.parametrize('pattern', [re.compile('.', re.DOTALL), '(?s).'])
+    def test_any_with_dotall_generate_newline(self, pattern):
+        h.find(regex(pattern), lambda s: s == '\n')
 
     def test_range(self):
         assert_can_generate('[a-z0-9_]')
@@ -29,21 +177,95 @@ class TestRegexStrategy:
     def test_negative_range(self):
         assert_can_generate('[^a-z0-9_]')
 
-    def test_categories(self):
-        assert_can_generate('\d')
-        assert_can_generate('\D')
-        assert_can_generate('\w')
-        assert_can_generate('\W')
-        assert_can_generate('\s')
-        assert_can_generate('\S')
+    @pytest.mark.parametrize('pattern', [r'\d', '[\d]', '[^\D]'])
+    def test_ascii_digits(self, pattern):
+        strategy = regex(ascii_regex(pattern))
 
-    def test_categories_in_range(self):
-        assert_can_generate('[\d]')
-        assert_can_generate('[\D]')
-        assert_can_generate('[\w]')
-        assert_can_generate('[\W]')
-        assert_can_generate('[\s]')
-        assert_can_generate('[\S]')
+        assert_all_examples(strategy, lambda s: is_digit(s) and is_ascii(s))
+
+    @pytest.mark.parametrize('pattern', [r'\d', '[\d]', '[^\D]'])
+    def test_unicode_digits(self, pattern):
+        strategy = regex(unicode_regex(pattern))
+
+        h.find(strategy, lambda s: is_digit(s) and is_ascii(s))
+        h.find(strategy, lambda s: is_digit(s) and not is_ascii(s))
+
+        assert_all_examples(strategy, is_digit)
+
+    @pytest.mark.parametrize('pattern', [r'\D', '[\D]', '[^\d]'])
+    def test_ascii_non_digits(self, pattern):
+        strategy = regex(ascii_regex(pattern))
+
+        assert_all_examples(strategy, lambda s: not is_digit(s) and is_ascii(s))
+
+    @pytest.mark.parametrize('pattern', [r'\D', '[\D]', '[^\d]'])
+    def test_unicode_non_digits(self, pattern):
+        strategy = regex(unicode_regex(pattern))
+
+        h.find(strategy, lambda s: not is_digit(s) and is_ascii(s))
+        h.find(strategy, lambda s: not is_digit(s) and not is_ascii(s))
+
+        assert_all_examples(strategy, lambda s: not is_digit(s))
+
+    @pytest.mark.parametrize('pattern', [r'\s', '[\s]', '[^\S]'])
+    def test_ascii_whitespace(self, pattern):
+        strategy = regex(ascii_regex(pattern))
+
+        assert_all_examples(strategy, lambda s: is_space(s) and is_ascii(s))
+
+    @pytest.mark.parametrize('pattern', [r'\s', '[\s]', '[^\S]'])
+    def test_unicode_whitespace(self, pattern):
+        strategy = regex(unicode_regex(pattern))
+
+        h.find(strategy, lambda s: is_unicode_space(s) and is_ascii(s))
+        h.find(strategy, lambda s: is_unicode_space(s) and not is_ascii(s))
+
+        assert_all_examples(strategy, is_unicode_space)
+
+    @pytest.mark.parametrize('pattern', [r'\S', '[\S]', '[^\s]'])
+    def test_ascii_non_whitespace(self, pattern):
+        strategy = regex(ascii_regex(pattern))
+
+        assert_all_examples(strategy, lambda s: not is_space(s) and is_ascii(s))
+
+    @pytest.mark.parametrize('pattern', [r'\S', '[\S]', '[^\s]'])
+    def test_unicode_non_whitespace(self, pattern):
+        strategy = regex(unicode_regex(pattern))
+
+        h.find(strategy, lambda s: not is_unicode_space(s) and is_ascii(s))
+        h.find(strategy, lambda s: not is_unicode_space(s) and not is_ascii(s))
+
+        assert_all_examples(strategy, lambda s: not is_unicode_space(s))
+
+    @pytest.mark.parametrize('pattern', [r'\w', '[\w]', '[^\W]'])
+    def test_ascii_word(self, pattern):
+        strategy = regex(ascii_regex(pattern))
+
+        assert_all_examples(strategy, lambda s: is_word(s) and is_ascii(s))
+
+    @pytest.mark.parametrize('pattern', [r'\w', '[\w]', '[^\W]'])
+    def test_unicode_word(self, pattern):
+        strategy = regex(unicode_regex(pattern))
+
+        h.find(strategy, lambda s: is_word(s) and is_ascii(s))
+        h.find(strategy, lambda s: is_word(s) and not is_ascii(s))
+
+        assert_all_examples(strategy, is_word)
+
+    @pytest.mark.parametrize('pattern', [r'\W', '[\W]', '[^\w]'])
+    def test_ascii_non_word(self, pattern):
+        strategy = regex(ascii_regex(pattern))
+
+        assert_all_examples(strategy, lambda s: not is_word(s) and is_ascii(s))
+
+    @pytest.mark.parametrize('pattern', [r'\W', '[\W]', '[^\w]'])
+    def test_unicode_non_word(self, pattern):
+        strategy = regex(unicode_regex(pattern))
+
+        h.find(strategy, lambda s: not is_word(s) and is_ascii(s))
+        h.find(strategy, lambda s: not is_word(s) and not is_ascii(s))
+
+        assert_all_examples(strategy, lambda s: not is_word(s))
 
     def test_question_mark_quantifier(self):
         assert_can_generate('ab?')
@@ -78,5 +300,37 @@ class TestRegexStrategy:
     def test_begining(self):
         assert_can_generate('^abc')
 
+    def test_caret_in_the_middle_does_not_generate_anything(self):
+        r = re.compile('a^b')
+
+        with pytest.raises(he.NoSuchExample):
+            h.find(regex(r), r.match)
+
     def test_end(self):
-        assert_can_generate('abc$')
+        strategy = regex('abc$')
+
+        h.find(strategy, lambda s: s == 'abc')
+        h.find(strategy, lambda s: s == 'abc\n')
+
+    def test_groupref_exists(self):
+        assert_all_examples(
+            regex('^(<)?a(?(1)>)$'),
+            lambda s: s in ('a', 'a\n', '<a>', '<a>\n')
+        )
+        assert_all_examples(
+            regex('^(a)?(?(1)b|c)$'),
+            lambda s: s in ('ab', 'ab\n', 'c', 'c\n')
+        )
+
+    @pytest.mark.skipif(sys.version_info[:2] < (3, 6), reason='requires Python 3.6')
+    def test_subpattern_flags(self):
+        strategy = regex('(?i)a(?-i:b)')
+
+        # "a" is case insensitive
+        h.find(strategy, lambda s: s[0] == 'a')
+        h.find(strategy, lambda s: s[0] == 'A')
+        # "b" is case sensitive
+        h.find(strategy, lambda s: s[1] == 'b')
+
+        with pytest.raises(he.NoSuchExample):
+            h.find(strategy, lambda s: s[1] == 'B')


### PR DESCRIPTION
Implement support for regex flags
    
This change adds support for re.IGNORECASE, re.DOTALL and
re.UNICODE regex flags. Flags are extracted from compiled
regex. Also, it supports subpattern flags introduced in
Python 3.6.
    
re.IGNORECASE controls literals: if it is enabled, instead
of generating static literal, it generates either
lowercase or uppercase character.
    
re.DOTALL: if enabled, "." matches newlines.
    
re.UNICODE controls character categories (e.g. "\d" or
"\w"): if enabled, categories include unicode characters.
In Python 2 default is to generate ASCII only data, in
Python 3 - unicode. Python 3 also has reverse flag -
re.ASCII to disable unicode character generation.

Fixes #2, #3 and #5