### PR TITLE
fix import error

### DIFF
--- a/hypothesis_regex.py
+++ b/hypothesis_regex.py
@@ -7,7 +7,6 @@ import sre_parse as sre
 import sys
 import hypothesis.errors as he
 import hypothesis.strategies as hs
-from hypothesis.searchstrategy.reprwrapper import ReprWrapperStrategy
 
 __all__ = ['regex']
 


### PR DESCRIPTION
reprwrapper is [gone](https://github.com/HypothesisWorks/hypothesis-python/commit/9a2a31c46811bc0dc344aa730e8a2295ffac0441) and unused in `hypothesis_regex.py` so removed.

Ran test suite for python 2.7.14 without any failures.